### PR TITLE
Added flatpak-xdg-utils module

### DIFF
--- a/io.github.raspirus.raspirus.yml
+++ b/io.github.raspirus.raspirus.yml
@@ -14,6 +14,13 @@ finish-args:
   - --filesystem=host
 
 modules:
+  - name: flatpak-xdg-utils
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/flatpak/flatpak-xdg-utils.git
+        tag: 1.0.6
+        commit: 05abdd7421688be5835a6b12f2b068086c38d4aa
   - name: raspirus-binary
     buildsystem: simple
     sources:


### PR DESCRIPTION
This should solve some issues about the File picker not opening on some operating systems. Issue reported on Discord